### PR TITLE
Simplified getGamepad function

### DIFF
--- a/src/input.luau
+++ b/src/input.luau
@@ -23,11 +23,11 @@ end
 	@method getGamepad
 	@param inputType
 	@return number
-	Returns the gamepad index of the given inputType, -1 if not a gamepad
+	Returns the gamepad index of the given inputType, 1 if not a gamepad
 ]=]
 local function getGamepad(inputType: Enum.UserInputType)
 	-- subtract from the Gamepad1 value to get the input
-	if inputType.Value < Enum.UserInputType.Gamepad1.Value or inputType.Value > Enum.UserInputType.Gamepad8.Value then return -1 end
+	if inputType.Value < Enum.UserInputType.Gamepad1.Value or inputType.Value > Enum.UserInputType.Gamepad8.Value then return 1 end
 	return inputType.Value - Enum.UserInputType.Gamepad1.Value + 1
 end
 


### PR DESCRIPTION
This pull request:
- Changes the getGamepad function to not use "if, elseif" statements, and instead uses a single check and basic arithmetic to accomplish the same goal, but in a cleaner way
- Removes an unnecessary ternary operator on the _reset function

please note that I haven't tested the code because it's 3:41AM and i want to go to sleep