### PR TITLE
fix: stale keyMap table reference causing inputs to not be updated (

### DIFF
--- a/src/input.luau
+++ b/src/input.luau
@@ -177,7 +177,6 @@ local function map<T>(input: types.Input<T>, keyMap: types.Map<T>)
 	for index, value in keyMap :: any do
 		local inputType = if type(index) == "number" then value else index
 		local modifier = if type(index) == "number" then 1 else value
-		newMap[index] = nil :: nil & T
 		newMap[inputType] = value
 		local autoType = type(modifier) ~= "number"
 
@@ -259,7 +258,7 @@ local function map<T>(input: types.Input<T>, keyMap: types.Map<T>)
 			end
 
 			active[enum] = (if inputObject.UserInputState == Enum.UserInputState.Begin or
-				inputObject.UserInputState == Enum.UserInputState.Change then keyMap[enum] else nil) :: (nil & T)
+				inputObject.UserInputState == Enum.UserInputState.Change then input.inputMap[enum] else nil) :: (nil & T)
 		end
 	end
 	table.insert(input.connections, UserInputService.InputBegan:Connect(inputBeganOrEnded))


### PR DESCRIPTION
I spent some time thoroughly debugging my code, `:pressed()`, `:pressing()`, etc. All always returned false. Touch inputs worked fine

After some digging through commit history I saw this line had been changed in commit `b5497d0` and reverting the change fixed the issue. I am sure this change had some point since it's been like this for months, so this PR is likely just for further discussion or helping me fix any error I might have made

I did build and play the example place. The roblox version